### PR TITLE
Mark Incomplete trajectories as failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       # TODO: Port to ROS2
       # DOWNSTREAM_WORKSPACE: "github:ubi-agni/mtc_demos#master github:TAMS-Group/mtc_pour#master"
       # Silent googletest warnings: https://github.com/ament/ament_cmake/pull/408#issuecomment-1306004975
-      # UPSTREAM_WORKSPACE: github:ament/googletest#clalancette/update-to-gtest-1.11
+      UPSTREAM_WORKSPACE: github:ament/googletest/rolling
       AFTER_SETUP_UPSTREAM_WORKSPACE: dpkg --purge --force-all ros-rolling-gtest-vendor ros-rolling-gmock-vendor
       TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       # TODO: Port to ROS2
       # DOWNSTREAM_WORKSPACE: "github:ubi-agni/mtc_demos#master github:TAMS-Group/mtc_pour#master"
       # Silent googletest warnings: https://github.com/ament/ament_cmake/pull/408#issuecomment-1306004975
-      UPSTREAM_WORKSPACE: github:ament/googletest/rolling
+      UPSTREAM_WORKSPACE: github:ament/googletest#rolling
       AFTER_SETUP_UPSTREAM_WORKSPACE: dpkg --purge --force-all ros-rolling-gtest-vendor ros-rolling-gmock-vendor
       TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       # TODO: Port to ROS2
       # DOWNSTREAM_WORKSPACE: "github:ubi-agni/mtc_demos#master github:TAMS-Group/mtc_pour#master"
       # Silent googletest warnings: https://github.com/ament/ament_cmake/pull/408#issuecomment-1306004975
-      UPSTREAM_WORKSPACE: github:ament/googletest#clalancette/update-to-gtest-1.11
+      # UPSTREAM_WORKSPACE: github:ament/googletest#clalancette/update-to-gtest-1.11
       AFTER_SETUP_UPSTREAM_WORKSPACE: dpkg --purge --force-all ros-rolling-gtest-vendor ros-rolling-gmock-vendor
       TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -80,6 +80,10 @@ public:
 		setProperty("path_constraints", std::move(path_constraints));
 	}
 
+	// To make sure the L1 distance between the goal state and the last waypoint in the planned trajectory
+	// are close enough.
+	void setGoalTolerance(float goal_tolerance) { setProperty("goal_tolerance", std::move(goal_tolerance)); }
+
 	void reset() override;
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 	void compute(const InterfaceState& from, const InterfaceState& to) override;

--- a/core/include/moveit/task_constructor/stages/connect.h
+++ b/core/include/moveit/task_constructor/stages/connect.h
@@ -97,6 +97,8 @@ protected:
 	moveit::core::JointModelGroupPtr merged_jmg_;
 	std::list<SubTrajectory> subsolutions_;
 	std::list<InterfaceState> states_;
+
+	std::string name_;
 };
 }  // namespace stages
 }  // namespace task_constructor

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -171,8 +171,8 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 			const auto distance = end->getCurrentState().distance(trajectory->getLastWayPoint());
 			if (distance > 0.05) {
 				RCLCPP_INFO_STREAM(LOGGER, "Stage Name : " << name_);
-				RCLCPP_INFO_STREAM(LOGGER, "The trajectory given by the plan function does not satisfy the goal state. " +
-				                               "Marking it as a failure");
+				RCLCPP_INFO_STREAM(LOGGER, "The trajectory given by the plan function does not satisfy the goal state. "
+				                               << "Marking it as a failure");
 				success = false;
 			}
 		}

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -59,6 +59,8 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 	p.declare<MergeMode>("merge_mode", WAYPOINTS, "merge mode");
 	p.declare<moveit_msgs::msg::Constraints>("path_constraints", moveit_msgs::msg::Constraints(),
 	                                         "constraints to maintain during trajectory");
+	p.declare<float>("goal_tolerance", 0.02,
+	                 "L1 distance between goal state and end of trajectory state should be within this tolerance");
 	properties().declare<TimeParameterizationPtr>("merge_time_parameterization",
 	                                              std::make_shared<TimeOptimalTrajectoryGeneration>());
 
@@ -169,7 +171,8 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 		// Check if the end goal and the last waypoint are close. The trajectory should be marked as failure otherwise.
 		if (success) {
 			const auto distance = end->getCurrentState().distance(trajectory->getLastWayPoint());
-			if (distance > 0.05) {
+			const auto& goal_tolerance = props.get<float>("goal_tolerance");
+			if (distance > goal_tolerance) {
 				RCLCPP_INFO_STREAM(LOGGER, "Stage Name : " << name_);
 				RCLCPP_INFO_STREAM(LOGGER, "The trajectory given by the plan function does not satisfy the goal state. "
 				                               << "Marking it as a failure");

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -60,7 +60,7 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 	p.declare<moveit_msgs::msg::Constraints>("path_constraints", moveit_msgs::msg::Constraints(),
 	                                         "constraints to maintain during trajectory");
 	p.declare<float>("goal_tolerance", 0.02,
-	                 "L1 distance between goal state and end of trajectory state should be within this tolerance");
+	                 "Distance between goal state and end of trajectory state should be within this tolerance");
 	properties().declare<TimeParameterizationPtr>("merge_time_parameterization",
 	                                              std::make_shared<TimeOptimalTrajectoryGeneration>());
 

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -171,7 +171,8 @@ void Connect::compute(const InterfaceState& from, const InterfaceState& to) {
 			const auto distance = end->getCurrentState().distance(trajectory->getLastWayPoint());
 			if (distance > 0.05) {
 				RCLCPP_INFO_STREAM(LOGGER, "Stage Name : " << name_);
-				RCLCPP_INFO_STREAM(LOGGER, "The trajectory given by the plan function does not satisfy the goal state. Marking it as a failure");
+				RCLCPP_INFO_STREAM(LOGGER, "The trajectory given by the plan function does not satisfy the goal state. " +
+				                               "Marking it as a failure");
 				success = false;
 			}
 		}


### PR DESCRIPTION
Sometimes, the plan function in the Connect stage returns success with an incomplete trajectory.
This predominantly happens when using pick_ik. Here is a band-aid fix to mark such trajectories as failure while I dig deeper to find the source of this error.

Video evidence of incomplete trajectories now marked as failure
https://github.com/PickNikRobotics/moveit_task_constructor/assets/17363793/e545e5c6-1574-4ac4-bc3e-5eb775e60f63

