### PR TITLE
Add quick fix

### DIFF
--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -57,7 +57,7 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 
 	auto& p = properties();
 	p.declare<MergeMode>("merge_mode", WAYPOINTS, "merge mode");
-	p.declare<double>("max_distance", 1e-4, "maximally accepted distance between end and goal sate");
+	p.declare<double>("max_distance", 1e-2, "maximally accepted distance between end and goal sate");
 	p.declare<moveit_msgs::msg::Constraints>("path_constraints", moveit_msgs::msg::Constraints(),
 	                                         "constraints to maintain during trajectory");
 	properties().declare<TimeParameterizationPtr>("merge_time_parameterization",


### PR DESCRIPTION
Looks like ROS2 uses a more relaxed goal constraint threshold than ROS1. For this reason, all end states reached by Connect solutions of pick+place demo are rejected. This commit relaxes the max_distance threshold of Connect as well.